### PR TITLE
Harden vote creation validation (prevent forged/invalid/duplicate votes)

### DIFF
--- a/includes/Controllers/VoteController.php
+++ b/includes/Controllers/VoteController.php
@@ -123,6 +123,7 @@ class VoteController {
                 $aliasCard = $this->cardModel->getCardById($card['alias']);
                 if ($aliasCard) {
                     $cardId = $card['alias'];
+                    $card = $aliasCard;
                 }
             }
 
@@ -133,8 +134,12 @@ class VoteController {
                 $errors[] = '请选择卡片';
             }
 
-            if ($environmentId <= 0) {
-                $errors[] = '请选择环境';
+            if (!$card) {
+                $errors[] = '卡片不存在';
+            }
+
+            if (!Utils::getEnvironmentById($environmentId)) {
+                $errors[] = '请选择有效的环境';
             }
 
             if ($status < 0 || $status > 3) {
@@ -383,8 +388,8 @@ class VoteController {
                 $errors[] = '请选择卡片';
             }
 
-            if ($environmentId <= 0) {
-                $errors[] = '请选择环境';
+            if (!Utils::getEnvironmentById($environmentId)) {
+                $errors[] = '请选择有效的环境';
             }
 
             if ($status < 0 || $status > 3) {
@@ -606,8 +611,8 @@ class VoteController {
             $errors[] = '请输入卡片ID列表';
         }
 
-        if ($environmentId <= 0) {
-            $errors[] = '请选择环境';
+        if (!Utils::getEnvironmentById($environmentId)) {
+            $errors[] = '请选择有效的环境';
         }
 
         if ($status < 0 || $status > 3) {
@@ -634,6 +639,10 @@ class VoteController {
             } else {
                 $invalidCardIds[] = $cardId;
             }
+        }
+
+        if (!empty($invalidCardIds)) {
+            $errors[] = '包含无效的卡片ID：' . implode('、', $invalidCardIds);
         }
 
         if (empty($validCardIds)) {
@@ -697,15 +706,38 @@ class VoteController {
         $reason = isset($_POST['reason']) ? trim($_POST['reason']) : '';
         $initiatorId = isset($_POST['initiator_id']) ? trim($_POST['initiator_id']) : '';
 
+        if (!Utils::getEnvironmentById($environmentId)) {
+            header('Location: ' . BASE_URL . '?controller=vote&action=createAdvanced&error=' . urlencode('请选择有效的环境'));
+            exit;
+        }
+
+        if ($status < 0 || $status > 3) {
+            header('Location: ' . BASE_URL . '?controller=vote&action=createAdvanced&error=' . urlencode('请选择有效的禁限状态'));
+            exit;
+        }
+
+        if (empty($reason) || empty($initiatorId)) {
+            header('Location: ' . BASE_URL . '?controller=vote&action=createAdvanced&error=' . urlencode('提交的高级投票参数不完整'));
+            exit;
+        }
+
         // 解析卡片ID列表
         $cardIds = $this->parseCardIds($cardIdsString);
         $validCardIds = [];
+        $invalidCardIds = [];
 
         foreach ($cardIds as $cardId) {
             $card = $this->cardModel->getCardById($cardId);
             if ($card) {
                 $validCardIds[] = $cardId;
+            } else {
+                $invalidCardIds[] = $cardId;
             }
+        }
+
+        if (!empty($invalidCardIds)) {
+            header('Location: ' . BASE_URL . '?controller=vote&action=createAdvanced&error=' . urlencode('包含无效的卡片ID：' . implode('、', $invalidCardIds)));
+            exit;
         }
 
         if (empty($validCardIds)) {

--- a/includes/Models/Vote.php
+++ b/includes/Models/Vote.php
@@ -40,6 +40,36 @@ class Vote {
      * @return string|false 投票链接或失败
      */
     public function createVote($cardId, $environmentId, $status, $reason, $initiatorId, $isSeriesVote = false, $setcode = 0, $isAdvancedVote = false, $cardIds = '') {
+        $cardId = (int)$cardId;
+        $environmentId = (int)$environmentId;
+        $status = (int)$status;
+        $initiatorId = trim($initiatorId);
+        $setcode = (int)$setcode;
+        $isSeriesVote = $isSeriesVote ? true : false;
+        $isAdvancedVote = $isAdvancedVote ? true : false;
+
+        if (!$this->isValidVoteStatus($status) || !$this->isValidEnvironmentId($environmentId) || $initiatorId === '') {
+            return false;
+        }
+
+        if ($isAdvancedVote) {
+            $normalizedCardIds = $this->normalizeAdvancedVoteCardIds($cardIds);
+            if (empty($normalizedCardIds)) {
+                return false;
+            }
+
+            $cardIds = json_encode($normalizedCardIds);
+            $cardId = $normalizedCardIds[0];
+        } else {
+            if (!$this->cardModel->getCardById($cardId)) {
+                return false;
+            }
+        }
+
+        if ($isSeriesVote && $setcode <= 0) {
+            return false;
+        }
+
         // 获取当前投票周期
         $voteCycle = $this->db->getCurrentVoteCycle();
 
@@ -97,6 +127,57 @@ class Vote {
         }
 
         return $voteLink;
+    }
+
+
+    /**
+     * 检查禁限状态是否有效
+     *
+     * @param int $status 禁限状态
+     * @return bool 是否有效
+     */
+    private function isValidVoteStatus($status) {
+        return $status >= 0 && $status <= 3;
+    }
+
+    /**
+     * 检查环境ID是否有效
+     *
+     * @param int $environmentId 环境ID
+     * @return bool 是否有效
+     */
+    private function isValidEnvironmentId($environmentId) {
+        return Utils::getEnvironmentById($environmentId) !== null;
+    }
+
+    /**
+     * 规范化高级投票的卡片ID列表
+     *
+     * @param string $cardIds 卡片ID列表（JSON格式）
+     * @return array 规范化后的卡片ID列表
+     */
+    private function normalizeAdvancedVoteCardIds($cardIds) {
+        $decodedCardIds = json_decode($cardIds, true);
+        if (!is_array($decodedCardIds)) {
+            return [];
+        }
+
+        $normalizedCardIds = [];
+        foreach ($decodedCardIds as $cardId) {
+            $cardId = (int)$cardId;
+            if ($cardId <= 0) {
+                continue;
+            }
+
+            if ($this->cardModel->getCardById($cardId)) {
+                $normalizedCardIds[] = $cardId;
+            }
+        }
+
+        $normalizedCardIds = array_values(array_unique($normalizedCardIds));
+        sort($normalizedCardIds);
+
+        return $normalizedCardIds;
     }
 
     /**


### PR DESCRIPTION
### Motivation

- 发现投票表中存在 initiator_id="1" 创建的重复、环境ID非法、card_id 不存在的投票，原因是服务端对创建投票的请求过于信任（仅依赖前端/页面流程验证）。

### Description

- 在 `VoteController` 的普通创建、系列创建与高级投票预览/确认流程中增加服务端校验，确保所提交的 `environment_id` 存在且有效、`card_id` 对应卡片真实存在，以及高级投票阶段拒绝包含无效卡片ID 的列表（修改文件：`includes/Controllers/VoteController.php`）。
- 在 `Vote` 模型的 `createVote()` 中加入模型层的第二道防线，对 `status`、`environment_id`、`initiator_id` 做强类型与合法性校验；对高级投票的 `card_ids` 进行反序列化、过滤无效卡、去重与排序后再重新编码并用于重复检测；拒绝不合规的系列投票（修改文件：`includes/Models/Vote.php`）。
- 新增/分离了小型辅助方法以保持逻辑清晰：`isValidVoteStatus()`、`isValidEnvironmentId()`、`normalizeAdvancedVoteCardIds()`，并修正 alias 处理以保证控制器中使用正确的卡片对象。

### Testing

- 运行 `php -l includes/Controllers/VoteController.php`，语法检查通过（无语法错误）。
- 运行 `php -l includes/Models/Vote.php`，语法检查通过（无语法错误）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b9f303f4c883268bf85398b0c29e28)