### PR TITLE
修复台词投稿节流回归并为作者ID增加白名单

### DIFF
--- a/includes/Controllers/DialogueController.php
+++ b/includes/Controllers/DialogueController.php
@@ -110,6 +110,7 @@ class DialogueController {
         $dialogue = Utils::getSafeParam($_POST, 'dialogue', 'string', '', PUBLIC_DIALOGUE_MAX_LENGTH);
         $authorId = Utils::getSafeParam($_POST, 'author_id', 'string', '', PUBLIC_IDENTIFIER_MAX_LENGTH);
         $userId = Utils::getSafeParam($_POST, 'user_id', 'string', '', PUBLIC_IDENTIFIER_MAX_LENGTH);
+        $authorIdWhitelist = $this->dialogueModel->getAuthorIdentifierWhitelist();
 
         if ($requestError !== null) {
             header('Location: ' . BASE_URL . '?controller=dialogue&action=submit&error=' . urlencode($requestError));
@@ -117,7 +118,7 @@ class DialogueController {
         }
 
         // 验证输入
-        if (empty($cardId) || !Utils::isValidPublicText($dialogue, PUBLIC_DIALOGUE_MAX_LENGTH) || !Utils::isValidPublicIdentifier($authorId) || !Utils::isValidPublicIdentifier($userId)) {
+        if (empty($cardId) || !Utils::isValidPublicText($dialogue, PUBLIC_DIALOGUE_MAX_LENGTH) || !Utils::isValidPublicIdentifier($authorId, $authorIdWhitelist) || !Utils::isValidPublicIdentifier($userId)) {
             header('Location: ' . BASE_URL . '?controller=dialogue&action=submit&error=' . urlencode('所有字段都是必填的'));
             exit;
         }
@@ -140,6 +141,17 @@ class DialogueController {
         $validation = $this->dialogueModel->validateAuthor($authorId, $cardId, DIALOGUE_SUBMISSION_STRICTNESS);
         if (!$validation['valid']) {
             header('Location: ' . BASE_URL . '?controller=dialogue&action=submit&error=' . urlencode($validation['message']));
+            exit;
+        }
+
+        $throttleError = Utils::throttlePublicWrite('dialogue_submit', Utils::buildPayloadHash([
+            'card_id' => $cardId,
+            'dialogue' => $dialogue,
+            'author_id' => $authorId,
+            'user_id' => $userId
+        ]));
+        if ($throttleError !== null) {
+            header('Location: ' . BASE_URL . '?controller=dialogue&action=submit&error=' . urlencode($throttleError));
             exit;
         }
 
@@ -456,13 +468,3 @@ class DialogueController {
         }
     }
 }
-        $throttleError = Utils::throttlePublicWrite('dialogue_submit', Utils::buildPayloadHash([
-            'card_id' => $cardId,
-            'dialogue' => $dialogue,
-            'author_id' => $authorId,
-            'user_id' => $userId
-        ]));
-        if ($throttleError !== null) {
-            header('Location: ' . BASE_URL . '?controller=dialogue&action=submit&error=' . urlencode($throttleError));
-            exit;
-        }

--- a/includes/Controllers/VoteController.php
+++ b/includes/Controllers/VoteController.php
@@ -118,6 +118,9 @@ class VoteController {
             $status = Utils::getSafeParam($_POST, 'status', 'int', 3);
             $reason = Utils::getSafeParam($_POST, 'reason', 'string', '', PUBLIC_VOTE_REASON_MAX_LENGTH);
             $initiatorId = Utils::getSafeParam($_POST, 'initiator_id', 'string', '', PUBLIC_IDENTIFIER_MAX_LENGTH);
+            $authorIdWhitelist = $this->getAuthorIdentifierWhitelist();
+            $authorIdWhitelist = $this->getAuthorIdentifierWhitelist();
+            $authorIdWhitelist = $this->getAuthorIdentifierWhitelist();
 
             // 检查卡片是否有alias字段，如果有则使用alias对应的卡片ID
             $card = $this->cardModel->getCardById($cardId);
@@ -151,7 +154,7 @@ class VoteController {
                 $errors[] = '请选择有效的禁限状态';
             }
 
-            if (!Utils::isValidPublicIdentifier($initiatorId)) {
+            if (!Utils::isValidPublicIdentifier($initiatorId, $authorIdWhitelist)) {
                 $errors[] = '请输入有效的ID';
             }
 
@@ -407,6 +410,7 @@ class VoteController {
             $status = Utils::getSafeParam($_POST, 'status', 'int', 3);
             $reason = Utils::getSafeParam($_POST, 'reason', 'string', '', PUBLIC_VOTE_REASON_MAX_LENGTH);
             $initiatorId = Utils::getSafeParam($_POST, 'initiator_id', 'string', '', PUBLIC_IDENTIFIER_MAX_LENGTH);
+            $authorIdWhitelist = $this->getAuthorIdentifierWhitelist();
 
             // 验证数据
             $errors = [];
@@ -426,7 +430,7 @@ class VoteController {
                 $errors[] = '请选择有效的禁限状态';
             }
 
-            if (!Utils::isValidPublicIdentifier($initiatorId)) {
+            if (!Utils::isValidPublicIdentifier($initiatorId, $authorIdWhitelist)) {
                 $errors[] = '请输入有效的ID';
             }
 
@@ -474,7 +478,7 @@ class VoteController {
             if ($strictness >= 3) {
                 // 需要额外验证卡片作者
                 $cardAuthorId = Utils::getSafeParam($_POST, 'card_author_id', 'string', '', PUBLIC_IDENTIFIER_MAX_LENGTH);
-                if (empty($cardAuthorId) || !Utils::isValidPublicIdentifier($cardAuthorId)) {
+                if (empty($cardAuthorId) || !Utils::isValidPublicIdentifier($cardAuthorId, $authorIdWhitelist)) {
                     $errors[] = '请填写卡片作者ID';
                 } else {
                     $isCardAuthorValid = $this->checkCardAuthorAuthorization($cardAuthorId, $card);
@@ -1027,6 +1031,35 @@ class VoteController {
         }
 
         return false;
+    }
+
+    /**
+     * 获取作者ID白名单（作者名 + 别名）
+     *
+     * @return array
+     */
+    private function getAuthorIdentifierWhitelist() {
+        $db = Database::getInstance();
+        $allMappings = $db->getRows('SELECT author_name, alias FROM author_mappings');
+        $whitelist = array();
+
+        foreach ($allMappings as $mapping) {
+            if (!empty($mapping['author_name'])) {
+                $whitelist[] = trim($mapping['author_name']);
+            }
+
+            if (!empty($mapping['alias'])) {
+                $aliases = explode(',', $mapping['alias']);
+                foreach ($aliases as $alias) {
+                    $alias = trim($alias);
+                    if ($alias !== '') {
+                        $whitelist[] = $alias;
+                    }
+                }
+            }
+        }
+
+        return array_values(array_unique($whitelist));
     }
 
     /**

--- a/includes/Core/Utils.php
+++ b/includes/Core/Utils.php
@@ -354,11 +354,16 @@ class Utils {
     /**
      * 验证公开标识符
      */
-    public static function isValidPublicIdentifier($value) {
-        return is_string($value)
-            && $value !== ''
-            && strlen($value) <= PUBLIC_IDENTIFIER_MAX_LENGTH
-            && preg_match('/^[A-Za-z0-9_\-\x{4e00}-\x{9fa5}\s]+$/u', $value);
+    public static function isValidPublicIdentifier($value, $exactWhitelist = array()) {
+        if (!is_string($value) || $value === '' || strlen($value) > PUBLIC_IDENTIFIER_MAX_LENGTH) {
+            return false;
+        }
+
+        if (!empty($exactWhitelist) && in_array($value, $exactWhitelist, true)) {
+            return true;
+        }
+
+        return preg_match('/^[A-Za-z0-9_\-\x{4e00}-\x{9fa5}\s]+$/u', $value) === 1;
     }
 
     /**

--- a/includes/Models/DialogueModel.php
+++ b/includes/Models/DialogueModel.php
@@ -330,4 +330,32 @@ class DialogueModel {
 
         return ['valid' => false, 'message' => '未知的严格度设置', 'warning' => false];
     }
+
+    /**
+     * 获取作者ID白名单（作者名 + 别名）
+     *
+     * @return array
+     */
+    public function getAuthorIdentifierWhitelist() {
+        $authorMapping = new AuthorMapping();
+        $allMappings = $authorMapping->getAllAuthorMappings();
+        $whitelist = [];
+
+        foreach ($allMappings as $mapping) {
+            if (!empty($mapping['author_name'])) {
+                $whitelist[] = trim($mapping['author_name']);
+            }
+            if (!empty($mapping['alias'])) {
+                $aliases = explode(',', $mapping['alias']);
+                foreach ($aliases as $alias) {
+                    $alias = trim($alias);
+                    if ($alias !== '') {
+                        $whitelist[] = $alias;
+                    }
+                }
+            }
+        }
+
+        return array_values(array_unique($whitelist));
+    }
 }


### PR DESCRIPTION
### Motivation
- 修复生产环境中访问 `?controller=dialogue` 被反复重定向并报错“提交过于频繁，请稍后再试”的问题，该问题由节流逻辑在文件层级错误执行导致。 
- 同时允许系统作者名单中的部分作者名包含非默认正则匹配字符（例如 `Ж`），以免被新的防注入/过滤规则阻断作者相关功能。 

### Description
- 将对公开写入的节流调用恢复到 `DialogueController::submitDialogue()` 的提交流程内（在表单与作者校验通过后执行），避免在文件加载时意外运行。 
- 为公开标识符校验函数 `Utils::isValidPublicIdentifier()` 增加可选的精确匹配白名单参数以支持受信任的特殊字符标识。 
- 在 `includes/Models/DialogueModel.php` 中新增 `getAuthorIdentifierWhitelist()`，从作者映射（作者名 + 逗号分隔别名）构造白名单并去重。 
- 在提交通道和系列投票创建中使用该白名单：`DialogueController::submitDialogue()`、`VoteController::createSeries()` 的 `author_id` / `initiator_id` / `card_author_id` 校验均改为调用带白名单的 `isValidPublicIdentifier()`，并在必要位置调用节流。 

### Testing
- 执行了语法检查：`php -l includes/Controllers/DialogueController.php`、`php -l includes/Core/Utils.php`、`php -l includes/Models/DialogueModel.php` 和 `php -l includes/Controllers/VoteController.php`，全部通过。 
- 在容器内通过静态检查确认无语法错误且所改函数被正确调用（`Utils::throttlePublicWrite`、`Utils::isValidPublicIdentifier`、`DialogueModel::getAuthorIdentifierWhitelist`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d467df16d083268e6130e64d77819c)