### PR TITLE
Fix advanced vote submissions rejected as Bad Request

### DIFF
--- a/includes/Core/Utils.php
+++ b/includes/Core/Utils.php
@@ -119,13 +119,54 @@ class Utils {
      * 拒绝包含数组污染的请求参数
      */
     public static function rejectInvalidRequestData() {
-        foreach (array($_GET, $_POST) as $bag) {
-            foreach ($bag as $key => $value) {
-                if (!self::isAllowedScalar($key, ROUTE_PARAM_MAX_LENGTH) || is_array($value)) {
-                    self::abort(400, 'Bad Request');
-                }
+        // GET 参数用于路由和查询，保持标量限制
+        foreach ($_GET as $key => $value) {
+            if (!self::isAllowedScalar($key, ROUTE_PARAM_MAX_LENGTH) || is_array($value)) {
+                self::abort(400, 'Bad Request');
             }
         }
+
+        // POST 参数允许数组（例如高级投票的 card_votes[card_id]），
+        // 但必须保证键名和值都为安全的标量或受限深度的数组，防止参数污染
+        if (!self::isValidRequestPayload($_POST, 0)) {
+            self::abort(400, 'Bad Request');
+        }
+    }
+
+    /**
+     * 验证请求负载结构
+     *
+     * @param mixed $payload 请求负载
+     * @param int $depth 当前递归深度
+     * @return bool
+     */
+    private static function isValidRequestPayload($payload, $depth = 0) {
+        $maxDepth = 4;
+        $maxArraySize = 512;
+        $maxFieldLength = defined('ROUTE_PARAM_MAX_LENGTH') ? ROUTE_PARAM_MAX_LENGTH * 64 : 4096;
+
+        if (!is_array($payload)) {
+            return self::isAllowedScalar($payload, $maxFieldLength);
+        }
+
+        if ($depth > $maxDepth || count($payload) > $maxArraySize) {
+            return false;
+        }
+
+        foreach ($payload as $key => $value) {
+            if (!self::isAllowedScalar($key, ROUTE_PARAM_MAX_LENGTH)) {
+                return false;
+            }
+            if (is_array($value)) {
+                if (!self::isValidRequestPayload($value, $depth + 1)) {
+                    return false;
+                }
+            } elseif (!self::isAllowedScalar($value, $maxFieldLength)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
### Motivation
- 高级投票表单会以数组形式提交各卡片的投票结果（例如 `card_votes[<card_id>]`），但以前的请求硬化逻辑在 `Utils::rejectInvalidRequestData()` 中把 `$_POST` 中的所有数组视为非法，导致在进入 `VoteController::submitAdvanced()` 前就返回 `400 Bad Request`。

### Description
- 将 `Utils::rejectInvalidRequestData()` 改为仅对 `$_GET` 保持严格“标量”限制，并允许对 `$_POST` 使用受限的数组结构校验。 
- 新增私有方法 `Utils::isValidRequestPayload()`，对 `$_POST` 进行递归验证并限制最大深度、最大数组项数、字段长度及键名安全性，以防止参数污染同时支持合法的表单数组（如高级投票的 `card_votes`）。
- 保持路由参数安全性，`GET` 参数校验规则未放宽以避免影响路由/入口安全。

### Testing
- 运行语法检查 `php -l includes/Core/Utils.php`，结果通过（无语法错误）；
- 运行语法检查 `php -l includes/Controllers/VoteController.php`，结果通过（无语法错误）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6866d28948326ac655b9ddc926dd6)