### PR TITLE
修复多字节字符串长度计算导致的投票理由计数异常

### DIFF
--- a/includes/Controllers/VoteController.php
+++ b/includes/Controllers/VoteController.php
@@ -354,8 +354,9 @@ class VoteController {
                     } elseif ($ban['ban_level'] == 1) {
                         // 等级1封禁：检查理由长度
                         $minLength = defined('SERIES_VOTING_REASON_MIN_LENGTH') ? SERIES_VOTING_REASON_MIN_LENGTH : 400;
-                        if (strlen($comment) < $minLength) {
-                            $errors[] = "由于您的投票受到限制，评论字数不足，至少需要 {$minLength} 个字符，当前为 " . strlen($comment) . " 个字符";
+                        $commentLength = Utils::getStringLength($comment);
+                        if ($commentLength < $minLength) {
+                            $errors[] = "由于您的投票受到限制，评论字数不足，至少需要 {$minLength} 个字符，当前为 {$commentLength} 个字符";
                         }
                     }
                 }
@@ -462,8 +463,9 @@ class VoteController {
 
             if ($strictness >= 1) {
                 // 需要填写理由
-                if (strlen($reason) < $minReasonLength) {
-                    $errors[] = "理由字数不足，至少需要 {$minReasonLength} 个字符，当前为 " . strlen($reason) . " 个字符";
+                $reasonLength = Utils::getStringLength($reason);
+                if ($reasonLength < $minReasonLength) {
+                    $errors[] = "理由字数不足，至少需要 {$minReasonLength} 个字符，当前为 {$reasonLength} 个字符";
                 }
             }
 
@@ -702,8 +704,9 @@ class VoteController {
 
         // 检查理由长度（使用系列投票的标准）
         $minReasonLength = defined('SERIES_VOTING_REASON_MIN_LENGTH') ? SERIES_VOTING_REASON_MIN_LENGTH : 400;
-        if (count($validCardIds) > 1 && strlen($reason) < $minReasonLength) {
-            $errors[] = "涉及多张卡片时，理由字数不足，至少需要 {$minReasonLength} 个字符，当前为 " . strlen($reason) . " 个字符";
+        $reasonLength = Utils::getStringLength($reason);
+        if (count($validCardIds) > 1 && $reasonLength < $minReasonLength) {
+            $errors[] = "涉及多张卡片时，理由字数不足，至少需要 {$minReasonLength} 个字符，当前为 {$reasonLength} 个字符";
         }
 
         if (!empty($errors)) {

--- a/includes/Core/Utils.php
+++ b/includes/Core/Utils.php
@@ -76,7 +76,25 @@ class Utils {
         if (!is_string($value)) {
             return false;
         }
-        return strlen($value) <= $maxLength;
+        return self::getStringLength($value) <= $maxLength;
+    }
+
+    /**
+     * 获取字符串长度（优先按 UTF-8 字符计数）
+     *
+     * @param string $value 输入字符串
+     * @return int
+     */
+    public static function getStringLength($value) {
+        if (!is_string($value)) {
+            return 0;
+        }
+
+        if (function_exists('mb_strlen')) {
+            return mb_strlen($value, 'UTF-8');
+        }
+
+        return strlen($value);
     }
 
     /**


### PR DESCRIPTION
### Motivation
- 修复生产上高级投票中用户输入多字节（中文）理由时前端显示为“0 字符”并无法提交的问题，根因是服务器端长度校验和安全参数判断使用按字节计算的 `strlen()` 导致多字节文本被误判为超长并被 `getSafeParam()` 丢弃或返回空值。 
- 同步检查并修复其它投票相关场景（普通投票受限评论、系列投票理由）中长度统计不一致导致的错误提示。 

### Description
- 在 `includes/Core/Utils.php` 中新增 `Utils::getStringLength()`，优先使用 `mb_strlen(..., 'UTF-8')` 计算字符数，若无 `mbstring` 扩展则回退到 `strlen()`，并将 `isAllowedScalar()` 的长度判定改为使用该方法。 
- 在 `includes/Controllers/VoteController.php` 中将涉及最小字数校验与错误提示从 `strlen()` 改为 `Utils::getStringLength()`（包括受限用户评论校验、系列投票理由校验和高级投票预览理由校验），并调整错误消息中的计数变量以展示字符数而不是字节数。 
- 本次修改覆盖通过 `Utils::getSafeParam(..., 'string', ..., maxLength)` 进入的字符串上限判定，避免中文/多字节文本被错误截断或置空。 

### Testing
- 运行语法检查 `php -l includes/Core/Utils.php` 成功（无语法错误）。
- 运行语法检查 `php -l includes/Controllers/VoteController.php` 成功（无语法错误）。
- 使用文本搜索确认替换长度检查场景，命令 `rg -n "strlen\((\$reason|\$comment)\)"` 未返回需修正的旧用法（已替换为 `Utils::getStringLength`）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e983d4e1508326bfb85245b19f9e3f)