### PR TITLE
修复：允许管理员批量上传大文本卡组，避免被 `400 Bad Request` 拦截

### DIFF
--- a/includes/Core/Utils.php
+++ b/includes/Core/Utils.php
@@ -161,10 +161,11 @@ class Utils {
     private static function isValidRequestPayload($payload, $depth = 0) {
         $maxDepth = 4;
         $maxArraySize = 512;
-        $maxFieldLength = defined('ROUTE_PARAM_MAX_LENGTH') ? ROUTE_PARAM_MAX_LENGTH * 64 : 4096;
+        $defaultFieldMaxLength = defined('ROUTE_PARAM_MAX_LENGTH') ? ROUTE_PARAM_MAX_LENGTH * 64 : 4096;
+        $largeTextFieldMaxLength = defined('LARGE_TEXT_FIELD_MAX_LENGTH') ? LARGE_TEXT_FIELD_MAX_LENGTH : 500000;
 
         if (!is_array($payload)) {
-            return self::isAllowedScalar($payload, $maxFieldLength);
+            return self::isAllowedScalar($payload, $defaultFieldMaxLength);
         }
 
         if ($depth > $maxDepth || count($payload) > $maxArraySize) {
@@ -179,8 +180,15 @@ class Utils {
                 if (!self::isValidRequestPayload($value, $depth + 1)) {
                     return false;
                 }
-            } elseif (!self::isAllowedScalar($value, $maxFieldLength)) {
-                return false;
+            } else {
+                $maxFieldLength = $defaultFieldMaxLength;
+                if (is_string($key) && in_array($key, array('batch_content', 'ydk_content', 'deck_content'), true)) {
+                    $maxFieldLength = $largeTextFieldMaxLength;
+                }
+
+                if (!self::isAllowedScalar($value, $maxFieldLength)) {
+                    return false;
+                }
             }
         }
 


### PR DESCRIPTION
### Motivation
- 管理员在“批量上传卡组”文本框粘贴大量内容（例如 `batch_content`）时，会被全局 POST 校验判为超长并返回 `400 Bad Request`，导致无法上传。
- 需要在不放宽整体安全检测（如参数污染、递归深度等）的前提下，给确认为卡组文本的字段一项合理的更大长度阈值。

### Description
- 在 `Utils::isValidRequestPayload` 中引入 `LARGE_TEXT_FIELD_MAX_LENGTH` 配置读取，并设置默认值为 `500000`，用于可选的大文本字段上限。
- 将原先统一的字段长度检查拆分为 `defaultFieldMaxLength`（默认严格上限）和对特定 POST 键名 `batch_content`、`ydk_content`、`deck_content` 的高阈值例外，使这些字段可以接受大型文本内容。
- 保留并未修改原有的键名校验、最大数组深度和最大数组大小检查，从而继续防止参数污染等风险。

### Testing
- 运行了语法检查：`php -l includes/Core/Utils.php`，结果通过（无语法错误）。
- 项目无自动化单元测试可运行，修改仅限请求校验逻辑并通过静态语法检查。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b38c0060832682f6e9d3dea972a4)